### PR TITLE
Add Mac install instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ additional development libraries.
 
 </details>
 
+<details>
+  <summary>On <b>Mac</b> (using <a href="https://www.brew.sh/">homebrew</a>) <i>(click to expand)</i></summary>
+    ```bash
+    brew install rust sdl2 sdl2_ttf
+    export LIBRARY_PATH="$LIBRARY_PATH:/opt/homebrew/lib"
+    cargo install lukaj
+    ```
+</details>
+
 ## Usage
 
 To compare two SVG files run:


### PR DESCRIPTION
Updates the README to add install steps for macOS.

~~However this should probably not be merged yet since I haven't been able to run the compiled binary.~~

Edit: I was not passing file args in, I'll open another PR to check for this case and warn the user?